### PR TITLE
Fix overlay intercepting clicks on upload and success pages

### DIFF
--- a/www/css/success.css
+++ b/www/css/success.css
@@ -22,14 +22,15 @@ body.success-page {
 }
 
 .success-container::before {
-	content: '';
-	position: absolute;
-	top: -50%;
-	right: -50%;
-	width: 200%;
-	height: 200%;
-	background: radial-gradient(circle, rgba(255, 192, 203, 0.1) 0%, transparent 70%);
-	animation: float 6s ease-in-out infinite;
+        content: '';
+        position: absolute;
+        top: -50%;
+        right: -50%;
+        width: 200%;
+        height: 200%;
+        pointer-events: none;
+        background: radial-gradient(circle, rgba(255, 192, 203, 0.1) 0%, transparent 70%);
+        animation: float 6s ease-in-out infinite;
 }
 
 @keyframes float {

--- a/www/css/upload.css
+++ b/www/css/upload.css
@@ -22,14 +22,15 @@ body.upload-page {
 }
 
 .upload-container::before {
-	content: '';
-	position: absolute;
-	top: -50%;
-	left: -50%;
-	width: 200%;
-	height: 200%;
-	background: radial-gradient(circle, rgba(255, 182, 193, 0.1) 0%, transparent 70%);
-	animation: rotate 20s linear infinite;
+        content: '';
+        position: absolute;
+        top: -50%;
+        left: -50%;
+        width: 200%;
+        height: 200%;
+        pointer-events: none;
+        background: radial-gradient(circle, rgba(255, 182, 193, 0.1) 0%, transparent 70%);
+        animation: rotate 20s linear infinite;
 }
 
 @keyframes rotate {

--- a/www/style.css
+++ b/www/style.css
@@ -221,11 +221,12 @@ h2 {
 }
 
 .footer {
-	text-align: center;
-	bottom: 30px;
-	right: 700px;
-	position: fixed;
-	padding: 20px;
-	color: #8e44ad;
-	font-size: 14px;
+       position: fixed;
+       left: 50%;
+       bottom: 10px;
+       transform: translateX(-50%);
+       padding: 20px;
+       text-align: center;
+       color: #8e44ad;
+       font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- prevent overlay before pseudo-elements from intercepting pointer events
- center footer on main page and avoid overlapping the status bar

## Testing
- `make -j2`
- `make test` *(fails: invalid use of incomplete type `ServerConfig`)*

------
https://chatgpt.com/codex/tasks/task_e_684b28b08fc08328904c1296c77076b6