### PR TITLE
Improve theme handling and visit tracking

### DIFF
--- a/www/cookie-demo.html
+++ b/www/cookie-demo.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Cookie Demo</title>
     <link rel="stylesheet" href="/style.css"/>
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
     <h1>Cookie Demo</h1>

--- a/www/error/400.html
+++ b/www/error/400.html
@@ -6,6 +6,7 @@ s<!DOCTYPE html>
 	<title>400 - Bad Request</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/401.html
+++ b/www/error/401.html
@@ -6,6 +6,7 @@
 	<title>401 - Unauthorized/Unauthenticated</title>
 	<link rel="stylesheet" href="/style.css"/>
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container"></div>

--- a/www/error/403.html
+++ b/www/error/403.html
@@ -6,6 +6,7 @@
 	<title>403 - Forbidden</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/404.html
+++ b/www/error/404.html
@@ -6,6 +6,7 @@
 	<title>404 - Not Found</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body >
 	<div class="error-container">

--- a/www/error/500.html
+++ b/www/error/500.html
@@ -6,6 +6,7 @@
 	<title>500 - Internal Server Error</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/502.html
+++ b/www/error/502.html
@@ -6,6 +6,7 @@
 	<title>502 - Bad Gateway</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/503.html
+++ b/www/error/503.html
@@ -6,6 +6,7 @@
 	<title>503 - Service Unavailable</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/504.html
+++ b/www/error/504.html
@@ -6,6 +6,7 @@
 	<title>504 - Gateway Timeout</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+    <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/form.html
+++ b/www/form.html
@@ -8,7 +8,8 @@
             padding-top: 100px;
         }
     </style>
-	</head>
+        <script src="/scripts/theme.js"></script>
+        </head>
 	<body>
 		<h1 style="text-align: center";>Check out all of our CGIs!!!</h1>
 		<hr style="height: 4px; background-color: #8c52ff; border: none; margin: 30px 0;">

--- a/www/index.html
+++ b/www/index.html
@@ -5,7 +5,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>My Cute Photo Gallery</title>
 	<link rel="stylesheet" href="/style.css"/>
-	<link rel="stylesheet" href="/css/main.css">
+        <link rel="stylesheet" href="/css/main.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<!-- Floating decorations -->
@@ -71,10 +72,13 @@
 		<div class="status-item">
 			<span>Photos: <span id="photoCount">0</span></span>
 		</div>
-		<div class="status-item">
-			<span>Port: <span id="port-span"></span></span>
-		</div>
-	</div>
+                <div class="status-item">
+                        <span>Port: <span id="port-span"></span></span>
+                </div>
+                <div class="status-item">
+                        <span>Visits: <span id="visit-count">0</span></span>
+                </div>
+        </div>
 
 	<script>
 		// Global variables
@@ -324,22 +328,7 @@
 		`;
 		document.head.appendChild(style);
 
-		// Read cookies and apply to main gallery
-		function applyCookiePreferences() {
-			const theme = getCookie('gallery_theme') || 'pink';
-			const personality = getCookie('personality_mode') || 'bubbly';
-			const visitorName = getCookie('visitor_name');
-
-			// Apply theme to gallery
-			document.body.className = `theme-${theme} personality-${personality}`;
-
-			// Show personalized welcome
-			if (visitorName) {
-				showWelcomeMessage(`Welcome back, ${visitorName}! ✨`);
-			}
-		}
-
-		document.addEventListener('DOMContentLoaded', applyCookiePreferences);
+                // Theme and visit counter handled by theme.js
 
 	</script>
 

--- a/www/scripts/theme.js
+++ b/www/scripts/theme.js
@@ -1,0 +1,27 @@
+function getCookie(name) {
+    const match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()\[\]\\/+^])/g, '\\$1') + '=([^;]*)'));
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
+function applyCookieTheme() {
+    const theme = getCookie('gallery_theme');
+    const personality = getCookie('personality_mode');
+    if (theme) document.body.classList.add('theme-' + theme);
+    if (personality) document.body.classList.add('personality-' + personality);
+    const visitCount = getCookie('visit_count');
+    if (visitCount) {
+        const el = document.getElementById('visit-count');
+        if (el) el.textContent = visitCount;
+    }
+}
+
+function showWelcomeMessage(msg) {
+    const div = document.createElement('div');
+    div.className = 'welcome-msg';
+    div.textContent = msg;
+    div.style.cssText = 'position:fixed;top:10px;left:50%;transform:translateX(-50%);background:#ff69b4;color:#fff;padding:10px 20px;border-radius:20px;z-index:1000;';
+    document.body.appendChild(div);
+    setTimeout(() => div.remove(), 3000);
+}
+
+document.addEventListener('DOMContentLoaded', applyCookieTheme);

--- a/www/style.css
+++ b/www/style.css
@@ -269,3 +269,18 @@ h2 {
 .home-link.secondary:hover {
 	background-color: #cc3366;
 }
+/* Theme backgrounds */
+body.theme-unicorn { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 50%, #fecfef 100%); }
+body.theme-cupcake { background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%); }
+body.theme-mermaid { background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); }
+body.theme-cotton_candy { background: linear-gradient(135deg, #d299c2 0%, #fef9d7 100%); }
+body.theme-rainbow { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 25%, #a8edea 50%, #d299c2 75%, #fef9d7 100%); }
+body.theme-starlight { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
+body.theme-fairy { background: linear-gradient(135deg, #c3cfe2 0%, #c3cfe2 100%); }
+body.theme-butterfly { background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%); }
+
+/* Simple welcome message styling */
+.welcome-msg {
+    font-weight: bold;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}

--- a/www/templates/success.html
+++ b/www/templates/success.html
@@ -5,7 +5,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Upload Successful!</title>
 	<link rel="stylesheet" href="/style.css">
-	<link rel="stylesheet" href="/css/success.css">
+        <link rel="stylesheet" href="/css/success.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="success-container">

--- a/www/upload.html
+++ b/www/upload.html
@@ -5,7 +5,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Upload Files</title>
 	<link rel="stylesheet" href="/style.css">
-	<link rel="stylesheet" href="/css/upload.css">
+        <link rel="stylesheet" href="/css/upload.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="upload-container">

--- a/www/web/playground.html
+++ b/www/web/playground.html
@@ -5,7 +5,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>42 WebServ - Developer's Playground</title>
 	<link rel="stylesheet" href="/style.css"/>
-	<link rel="stylesheet" href="/css/cgi-bin.css"/>
+        <link rel="stylesheet" href="/css/cgi-bin.css"/>
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="container">


### PR DESCRIPTION
## Summary
- add a small helper script `theme.js` that reads cookies
- support multiple theme backgrounds in `style.css`
- load theme script on every html page
- show visit counter on the gallery home page
- remove old inline cookie logic

## Testing
- `make`
- `python3 -m py_compile www/cgi-bin/magicalCookie.py`

------
https://chatgpt.com/codex/tasks/task_e_6851dcf39fe88328b06baa4942b29d85