### PR TITLE
Add cookie-based theme and visit counter across site

### DIFF
--- a/www/error/400.html
+++ b/www/error/400.html
@@ -1,4 +1,4 @@
-s<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
@@ -6,6 +6,7 @@ s<!DOCTYPE html>
 	<title>400 - Bad Request</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/401.html
+++ b/www/error/401.html
@@ -6,6 +6,7 @@
 	<title>401 - Unauthorized/Unauthenticated</title>
 	<link rel="stylesheet" href="/style.css"/>
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container"></div>

--- a/www/error/403.html
+++ b/www/error/403.html
@@ -6,6 +6,7 @@
 	<title>403 - Forbidden</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/404.html
+++ b/www/error/404.html
@@ -6,6 +6,7 @@
 	<title>404 - Not Found</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body >
 	<div class="error-container">

--- a/www/error/413.html
+++ b/www/error/413.html
@@ -6,6 +6,7 @@
     <title>413 - Payload Too Large</title>
     <link rel="stylesheet" href="/style.css">
     <link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body class="error-413">
     <div class="error-container">

--- a/www/error/500.html
+++ b/www/error/500.html
@@ -6,6 +6,7 @@
 	<title>500 - Internal Server Error</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/502.html
+++ b/www/error/502.html
@@ -6,6 +6,7 @@
 	<title>502 - Bad Gateway</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/503.html
+++ b/www/error/503.html
@@ -6,6 +6,7 @@
 	<title>503 - Service Unavailable</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/error/504.html
+++ b/www/error/504.html
@@ -6,6 +6,7 @@
 	<title>504 - Gateway Timeout</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/error.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="error-container">

--- a/www/form.html
+++ b/www/form.html
@@ -8,6 +8,7 @@
             padding-top: 100px;
         }
     </style>
+        <script src="/scripts/theme.js"></script>
 	</head>
 	<body>
 		<h1 style="text-align: center";>Check out all of our CGIs!!!</h1>

--- a/www/index.html
+++ b/www/index.html
@@ -6,6 +6,7 @@
 	<title>My Cute Photo Gallery</title>
 	<link rel="stylesheet" href="/style.css"/>
 	<link rel="stylesheet" href="/css/main.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<!-- Floating decorations -->

--- a/www/scripts/theme.js
+++ b/www/scripts/theme.js
@@ -3,16 +3,36 @@ function getCookie(name) {
     return match ? decodeURIComponent(match[1]) : null;
 }
 
+function setCookie(name, value, days) {
+    const expires = new Date(Date.now() + days * 864e5).toUTCString();
+    document.cookie = name + '=' + encodeURIComponent(value) + '; Path=/; Expires=' + expires;
+}
+
+function incrementVisitCount() {
+    let count = parseInt(getCookie('visit_count') || '0', 10) + 1;
+    setCookie('visit_count', count, 365);
+    return count;
+}
+
+function ensureVisitBadge(count) {
+    let badge = document.getElementById('visit-badge');
+    if (!badge) {
+        badge = document.createElement('div');
+        badge.id = 'visit-badge';
+        badge.style.cssText = 'position:fixed;bottom:10px;right:10px;' +
+            'background:rgba(255,255,255,0.8);color:#ff1493;padding:4px 12px;' +
+            'border-radius:12px;font-size:0.9rem;z-index:999;box-shadow:0 0 5px rgba(0,0,0,0.2)';
+        badge.innerHTML = 'Visits: <span id="visit-count"></span>';
+        document.body.appendChild(badge);
+    }
+    document.getElementById('visit-count').textContent = count;
+}
+
 function applyCookieTheme() {
     const theme = getCookie('gallery_theme');
     const personality = getCookie('personality_mode');
     if (theme) document.body.classList.add('theme-' + theme);
     if (personality) document.body.classList.add('personality-' + personality);
-    const visitCount = getCookie('visit_count');
-    if (visitCount) {
-        const el = document.getElementById('visit-count');
-        if (el) el.textContent = visitCount;
-    }
 }
 
 function showWelcomeMessage(msg) {
@@ -24,4 +44,8 @@ function showWelcomeMessage(msg) {
     setTimeout(() => div.remove(), 3000);
 }
 
-document.addEventListener('DOMContentLoaded', applyCookieTheme);
+document.addEventListener('DOMContentLoaded', () => {
+    const count = incrementVisitCount();
+    applyCookieTheme();
+    ensureVisitBadge(count);
+});

--- a/www/style.css
+++ b/www/style.css
@@ -269,3 +269,12 @@ h2 {
 .home-link.secondary:hover {
 	background-color: #cc3366;
 }
+/* Theme backgrounds */
+body.theme-unicorn { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 50%, #fecfef 100%); }
+body.theme-cupcake { background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%); }
+body.theme-mermaid { background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); }
+body.theme-cotton_candy { background: linear-gradient(135deg, #d299c2 0%, #fef9d7 100%); }
+body.theme-rainbow { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 25%, #a8edea 50%, #d299c2 75%, #fef9d7 100%); }
+body.theme-starlight { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
+body.theme-fairy { background: linear-gradient(135deg, #c3cfe2 0%, #c3cfe2 100%); }
+body.theme-butterfly { background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%); }

--- a/www/templates/success.html
+++ b/www/templates/success.html
@@ -6,6 +6,7 @@
 	<title>Upload Successful!</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/success.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="success-container">

--- a/www/upload.html
+++ b/www/upload.html
@@ -6,6 +6,7 @@
 	<title>Upload Files</title>
 	<link rel="stylesheet" href="/style.css">
 	<link rel="stylesheet" href="/css/upload.css">
+        <script src="/scripts/theme.js"></script>
 </head>
 <body>
 	<div class="upload-container">

--- a/www/web/playground.html
+++ b/www/web/playground.html
@@ -6,6 +6,7 @@
 	<title>42 WebServ - Developer's Playground</title>
 	<link rel="stylesheet" href="/style.css"/>
 	<link rel="stylesheet" href="/css/cgi-bin.css"/>
+        <script src="/scripts/theme.js"></script>
 </head>
 <body class="cgi-bin">
 	<div class="container">


### PR DESCRIPTION
## Summary
- add theme.js to all HTML pages so theme applies everywhere
- create visit counter badge and store visits in cookie
- expose theme colors via CSS classes

## Testing
- `make test_full` *(fails: couldn't connect to localhost)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb9d9e1483289e0ab43fcd4e8e32