### PR TITLE
Fix chunked transfer send errors

### DIFF
--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -133,6 +133,7 @@ std::string	formatCGIResponse(const std::string& scriptOutput);
 // Chunked transfer functions (no class needed!)
 bool		useChunkedTransfer(const std::string& fullPath);
 bool		sendFileChunked(int fd, const std::string& fullPath, const std::string& contentType);
+bool            sendAll(int fd, const char* buffer, size_t length);
 
 // Enhanced PUT handling functions
 void		handleFileRename(int fd, const std::string& path, const std::string& newName,

--- a/srcs/helperFunction.cpp
+++ b/srcs/helperFunction.cpp
@@ -55,6 +55,24 @@ bool	safe_listen(int socket, int backlog) {
 	return true;
 }
 
+bool sendAll(int fd, const char* buffer, size_t length) {
+    size_t totalSent = 0;
+    while (totalSent < length) {
+        ssize_t sent = send(fd, buffer + totalSent, length - totalSent, 0);
+        if (sent < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                usleep(1000);
+                continue;
+            }
+            return false;
+        }
+        if (sent == 0)
+            return false;
+        totalSent += sent;
+    }
+    return true;
+}
+
 std::string	trim(std::string& s) {
 	size_t	start = s.find_first_not_of(" \t\r\n");
 	size_t end = s.find_last_not_of(" \t\r\n");
@@ -241,10 +259,9 @@ std::string extractBoundary(const std::string& request) {
 void sendHtmlResponse(int fd, int code, const std::string& body) {
 
 	std::string response = Response::build(code, body, "text/html");
-	ssize_t sent = send(fd, response.c_str(), response.size(), 0);
-	if (sent != (ssize_t)response.size()) {
-		std::cerr << "❌ Failed to send response for status code: " << sent << " of " << response.size() << " bytes\n";
-	}
+        if (!sendAll(fd, response.c_str(), response.size())) {
+                std::cerr << "❌ Failed to send response for status code: " << code << "\n";
+        }
 }
 
 /*
@@ -424,12 +441,11 @@ bool sendFileChunked(int fd, const std::string& fullPath, const std::string& con
 	std::string headerStr = headers.str();
 //	std::cout << "📤 Sending chunked headers (" << headerStr.size() << " bytes)" << std::endl;
 
-	ssize_t headerSent = send(fd, headerStr.c_str(), headerStr.size(), 0);
-	if (headerSent != (ssize_t)headerStr.size()) {
-		std::cerr << "❌ Failed to send chunked headers" << std::endl;
-		file.close();
-		return false;
-	}
+	if (!sendAll(fd, headerStr.c_str(), headerStr.size())) {
+        std::cerr << "❌ Failed to send chunked headers" << std::endl;
+        file.close();
+        return false;
+    }
 
 	// Send file in chunks
 	char buffer[65536];
@@ -446,21 +462,21 @@ bool sendFileChunked(int fd, const std::string& fullPath, const std::string& con
 		std::string chunkHeaderStr = chunkHeader.str();
 
 		// Send chunk size
-		if (send(fd, chunkHeaderStr.c_str(), chunkHeaderStr.size(), 0) != (ssize_t)chunkHeaderStr.size()) {
+		if (!sendAll(fd, chunkHeaderStr.c_str(), chunkHeaderStr.size())) {
 //			std::cerr << "❌ Failed to send chunk header" << std::endl;
 			file.close();
 			return false;
 		}
 
 		// Send chunk data
-		if (send(fd, buffer, bytesRead, 0) != (ssize_t)bytesRead) {
+		if (!sendAll(fd, buffer, bytesRead)) {
 //			std::cerr << "❌ Failed to send chunk data" << std::endl;
 			file.close();
 			return false;
 		}
 
 		// Send chunk trailing CRLF
-		if (send(fd, "\r\n", 2, 0) != 2) {
+		if (!sendAll(fd, "\r\n", 2)) {
 //			std::cerr << "❌ Failed to send chunk trailer" << std::endl;
 			file.close();
 			return false;
@@ -472,7 +488,7 @@ bool sendFileChunked(int fd, const std::string& fullPath, const std::string& con
 	file.close();
 
 	// Send final chunk (size 0) to indicate end
-	if (send(fd, "0\r\n\r\n", 5, 0) != 5) {
+	if (!sendAll(fd, "0\r\n\r\n", 5)) {
 		std::cerr << "❌ Failed to send final chunk" << std::endl;
 		return false;
 	}


### PR DESCRIPTION
## Summary
- add `sendAll` helper to handle partial writes on non-blocking sockets
- use `sendAll` when sending HTML responses and chunked data

## Testing
- `make`
- `make test` *(fails: invalid use of incomplete type)*

------
https://chatgpt.com/codex/tasks/task_e_6865b4495b708328b618b9a19d11e12f